### PR TITLE
#2 Add behat.skip_web_driver_launch configuration option

### DIFF
--- a/src/Blt/Plugin/Commands/BehatTestCommand.php
+++ b/src/Blt/Plugin/Commands/BehatTestCommand.php
@@ -70,9 +70,13 @@ class BehatTestCommand extends TestsCommandBase {
     $this->createReportsDir();
 
     try {
-      $this->launchWebDriver();
+      if (!$this->getConfigValue('behat.skip_web_driver_launch')) {
+        $this->launchWebDriver();
+      }
       $this->executeBehatTests();
-      $this->killWebDriver();
+      if (!$this->getConfigValue('behat.skip_web_driver_launch')) {
+        $this->killWebDriver();
+      }
     }
     catch (\Exception $e) {
       // Kill web driver a server to prevent Pipelines from hanging after fail.


### PR DESCRIPTION
See #2, this PR implements Option 1 from there.

Adds a new `behat.skip_web_driver_launch` option that decides if the web driver needs to be handled by blt.
This change is keeping the original behavior by default.
