### PR TITLE
Fixes #8: re-adds the container logic for TestsWizard.

### DIFF
--- a/src/Blt/Plugin/Commands/BehatTestCommand.php
+++ b/src/Blt/Plugin/Commands/BehatTestCommand.php
@@ -28,6 +28,7 @@ class BehatTestCommand extends TestsCommandBase {
   public function initialize() {
     parent::initialize();
     $this->behatLogDir = $this->getConfigValue('tests.reports.localDir') . "/behat";
+    $this->container->add(TestsWizard::class)->withArgument('executor');
   }
 
   /**


### PR DESCRIPTION
Fixes #8

This PR uses the initialize method to add the TestsWizard into the container. This is a slightly different method than was removed in https://github.com/acquia/blt/pull/4305/files#diff-410c7e892bb521b86d5c74c234a4b2f3bc56e62db1389adcd8c466b6507937d4L227 but it seems to work in my testing. 