### PR TITLE
Allow setting different example file per environment.

### DIFF
--- a/src/Blt/Plugin/Commands/BehatTestCommand.php
+++ b/src/Blt/Plugin/Commands/BehatTestCommand.php
@@ -57,7 +57,10 @@ class BehatTestCommand extends TestsCommandBase {
         }
     }
 
-    $defaultBehatLocalConfigFile = $this->getConfigValue('repo.root') . '/tests/behat/example.local.yml';
+    // Allow setting different example file per environment or other conditions.
+    $defaultBehatLocalConfigFilePath = $this->getConfigValue('behat.example_file', '/tests/behat/example.local.yml');
+
+    $defaultBehatLocalConfigFile = $this->getConfigValue('repo.root') . $defaultBehatLocalConfigFilePath;
     $projectBehatLocalConfigFile = $this->getConfigValue('repo.root') . '/tests/behat/local.yml';
     $copy_map = [
       $defaultBehatLocalConfigFile => $projectBehatLocalConfigFile,


### PR DESCRIPTION
Or other conditions.

For example, I might want to use different driver on CI environment.

This is important today as we have Apple M1 laptops for local and they need special / different configurations.

Post this, I can add following in my ci.blt.yml
```
behat:
  example_file: '/tests/behat/example.ci.yml'
```
